### PR TITLE
Add CI/CD Pipeline and Response Viewer Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,12 @@ name: CI/CD
 on:
   push:
     branches: [ main, master ]
-    tags:
-      - 'v*'
   pull_request:
     branches: [ main, master ]
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   test:
@@ -23,10 +22,26 @@ jobs:
           cache: 'npm'
       - run: npm install
       - run: npm test
+      - name: Build Verification
+        run: npm run build
 
-  release:
+  release-please:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
     needs: test
-    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        id: release
+        with:
+          release-type: node
+
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+
+  release-assets:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/src/renderer/components/ResponseViewer.tsx
+++ b/src/renderer/components/ResponseViewer.tsx
@@ -51,6 +51,26 @@ const Tabs = styled.div`
   gap: 20px;
   border-bottom: 1px solid #3e3e42;
   margin-top: 10px;
+  align-items: center;
+`;
+
+const Spacer = styled.div`
+  flex: 1;
+`;
+
+const ActionButton = styled.button`
+  padding: 4px 12px;
+  background-color: #3c3c3c;
+  color: #cccccc;
+  border: 1px solid #3e3e42;
+  cursor: pointer;
+  border-radius: 4px;
+  font-size: 12px;
+  margin-bottom: 5px;
+
+  &:hover {
+    background-color: #4c4c4c;
+  }
 `;
 
 const Tab = styled.div<{ $active?: boolean }>`
@@ -196,6 +216,24 @@ export const ResponseViewer = observer(() => {
     }
   }
 
+  const handleCopy = () => {
+    const text = formatBody(data);
+    navigator.clipboard.writeText(text).catch(err => console.error('Failed to copy: ', err));
+  };
+
+  const handleDownload = () => {
+    const text = formatBody(data);
+    const blob = new Blob([text], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'response.json';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <ViewerContainer>
       <ResponseMeta>
@@ -209,6 +247,14 @@ export const ResponseViewer = observer(() => {
         <Tab $active={activeTab === 'preview'} onClick={() => setActiveTab('preview')}>Preview</Tab>
         <Tab $active={activeTab === 'headers'} onClick={() => setActiveTab('headers')}>Headers</Tab>
         <Tab $active={activeTab === 'tests'} onClick={() => setActiveTab('tests')}>Test Results ({passedCount}/{totalTests})</Tab>
+        {activeTab === 'body' && (
+            <>
+                <Spacer />
+                <ActionButton onClick={handleCopy} title="Copy to Clipboard">Copy</ActionButton>
+                <div style={{ width: 10 }} />
+                <ActionButton onClick={handleDownload} title="Download Response">Download</ActionButton>
+            </>
+        )}
       </Tabs>
 
       <TabContent>

--- a/src/renderer/components/ResponseViewerCopy.test.tsx
+++ b/src/renderer/components/ResponseViewerCopy.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ResponseViewer } from './ResponseViewer';
+import { requestStore } from '../stores/RequestStore';
+import '@testing-library/jest-dom';
+import { runInAction } from 'mobx';
+import { vi, describe, beforeEach, it, expect } from 'vitest';
+
+// Mock clipboard and URL
+Object.assign(navigator, {
+  clipboard: {
+    writeText: vi.fn().mockImplementation(() => Promise.resolve()),
+  },
+});
+
+global.URL.createObjectURL = vi.fn(() => 'mock-url');
+global.URL.revokeObjectURL = vi.fn();
+
+describe('ResponseViewer Copy/Download', () => {
+  beforeEach(() => {
+    runInAction(() => {
+      requestStore.response = {
+        data: { test: 'value' },
+        status: 200,
+        statusText: 'OK',
+        headers: { 'content-type': 'application/json' },
+        testResults: [],
+      };
+      requestStore.loading = false;
+      requestStore.error = null;
+      // Reset metrics to avoid undefined errors if component accesses them
+      requestStore.responseMetrics = { time: 100, size: '1KB' };
+    });
+    vi.clearAllMocks();
+  });
+
+  it('copies response body to clipboard', async () => {
+    render(<ResponseViewer />);
+
+    const copyBtn = screen.getByText('Copy');
+    fireEvent.click(copyBtn);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      JSON.stringify({ test: 'value' }, null, 2)
+    );
+  });
+
+  it('downloads response body', async () => {
+    render(<ResponseViewer />);
+
+    const linkClickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click');
+
+    const downloadBtn = screen.getByText('Download');
+    fireEvent.click(downloadBtn);
+
+    expect(global.URL.createObjectURL).toHaveBeenCalled();
+    expect(linkClickSpy).toHaveBeenCalled();
+
+    linkClickSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Implemented robust CI/CD pipeline using GitHub Actions with `release-please` for semantic versioning and automated releases. 
Updated `.github/workflows/ci.yml` to include build verification and release jobs.
Added 'Copy' and 'Download' buttons to the `ResponseViewer` component for easier response body handling.
Added `src/renderer/components/ResponseViewerCopy.test.tsx` to verify the new buttons.

---
*PR created automatically by Jules for task [873218239520878568](https://jules.google.com/task/873218239520878568) started by @juninmd*