### PR TITLE
docs: add installation and build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,21 @@ This will start the Vite dev server and launch the Electron app.
 
 ### Building
 
-To build the application for production:
+To build the application for production locally:
 
 ```bash
 npm run build
 npm start
 ```
+
+### Building for Distribution (Installers)
+
+To create the installers for distribution (Windows .exe, Linux .AppImage):
+
+```bash
+npm run dist
+```
+
+The output files will be located in the `release/` directory:
+- **Windows:** `PingHermano Setup <version>.exe`
+- **Linux:** `PingHermano-<version>.AppImage`


### PR DESCRIPTION
Added a "Building for Distribution" section to README.md to explain how to generate installers for Windows (.exe) and Linux (.AppImage) using `npm run dist`.
This clarifies the installation process for users who want to run the application from source or build the distributable artifacts.

---
*PR created automatically by Jules for task [9010077497727585967](https://jules.google.com/task/9010077497727585967) started by @juninmd*